### PR TITLE
allowed PATH in default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Configures the **Access-Control-Allow-Credentials** CORS header. Expects a Boole
 
 ### allowMethods
 
-Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited array , If not specified, default allowMethods is `['GET', 'PUT', 'POST', 'DELETE', 'HEAD', 'OPTIONS']`.
+Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited array , If not specified, default allowMethods is `['GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']`.
 
 ### allowHeaders
 Configures the **Access-Control-Allow-Headers** CORS header. Expects a comma-delimited array . If not specified, defaults to reflecting the headers specified in the request's **Access-Control-Request-Headers** header.

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@
  */
 module.exports = function crossOrigin(options = {}) {
   const defaultOptions = {
-    allowMethods: ['GET', 'PUT', 'POST', 'DELETE', 'HEAD', 'OPTIONS'],
+    allowMethods: ['GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
   };
 
   // set defaultOptions to options


### PR DESCRIPTION
Hi @zadzbw ,
Please, include PATCH into default options -- there are a lot of apps which use **koa-cors**, where PATCH methods is included by default
Thank you,
Iurii
